### PR TITLE
Fix dotfiles repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@
 - [SigMacro](https://github.com/ywatanabe1989/SigMacro)
 
 #### Dotfiles
-- [.dotfiles-public](https://github.com/ywatanabe1989/.dotfiles-public)
+- [.dotfiles_public](https://github.com/ywatanabe1989/.dotfiles_public)
 
   
 


### PR DESCRIPTION
## Summary
Fix broken dotfiles repository link in README.md

- Update link from `.dotfiles-public` to `.dotfiles_public` 
- Resolves 404 error when accessing dotfiles repository from profile README
- Ensures README links point to actual repository name

## Context
Related to issue #22 - while the dotfiles repository was successfully updated, the README still references the old repository name with hyphen instead of underscore.

## Changes
- Line 53: `.dotfiles-public` → `.dotfiles_public`

🤖 Generated with [Claude Code](https://claude.ai/code)